### PR TITLE
Add Prompt model

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem 'puma', '~> 3.11'
 gem 'bcrypt', '~> 3.1.7'
 gem 'jwt'
 
+gem 'aasm'
 gem 'active_model_serializers', '~> 0.10.0'
 gem 'memoist'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    aasm (5.0.6)
+      concurrent-ruby (~> 1.0)
     actioncable (6.0.0)
       actionpack (= 6.0.0)
       nio4r (~> 2.0)
@@ -182,6 +184,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aasm
   active_model_serializers (~> 0.10.0)
   bcrypt (~> 3.1.7)
   bootsnap (>= 1.4.2)

--- a/app/controllers/api/v1/concerns/authenticate_request.rb
+++ b/app/controllers/api/v1/concerns/authenticate_request.rb
@@ -16,6 +16,10 @@ module API
           render_unauthorized unless current_user.present?
         end
 
+        def authenticate_admin!
+          render_unauthorized unless current_user&.admin?
+        end
+
         memoize def current_user
           return unless jwt_payload.present?
 

--- a/app/controllers/api/v1/entries_controller.rb
+++ b/app/controllers/api/v1/entries_controller.rb
@@ -31,7 +31,8 @@ module API
         entry = current_user.entries.find_by_id(entry_id)
         return render_not_found('Entry') if entry.nil?
 
-        entry.destroy
+        return render_bad_request('Could not delete entry') unless entry.destroy
+
         head :no_content
       end
 

--- a/app/controllers/api/v1/prompts_controller.rb
+++ b/app/controllers/api/v1/prompts_controller.rb
@@ -38,6 +38,18 @@ module API
         render json: prompt, serializer: PromptSerializer, status: :created
       end
 
+      # Allow user to delete own prompt
+      # Eventually replace with a :deleted state
+      def destroy
+        prompt = current_user.prompts.find_by_id(prompt_id)
+        return render_not_found('Prompt') if prompt.nil?
+
+        destroyed = prompt.destroy
+        return render_bad_request('Could not delete prompt') unless destroyed
+
+        head :no_content
+      end
+
       def approve
         transition_state(:approve)
       end

--- a/app/controllers/api/v1/prompts_controller.rb
+++ b/app/controllers/api/v1/prompts_controller.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module API
+  module V1
+    # This is the v1 controller for the Prompt model
+    class PromptsController < APIController
+      include Concerns::AuthenticateRequest
+      include Concerns::CommonRenders
+
+      before_action :authenticate_request!
+
+      def index
+        render json: Prompt.approved, each_serializer: PromptSerializer
+      end
+
+      def show
+        prompt = Prompt.approved.find_by_id(prompt_id)
+        return render_not_found('Prompt') if prompt.nil?
+
+        render json: prompt, serializer: PromptSerializer, status: :ok
+      end
+
+      def update
+        prompt = current_user.prompts.find_by_id(prompt_id)
+        return render_not_found('Prompt') if prompt.nil?
+
+        updated = prompt.update(prompt_params)
+        return render_bad_request(prompt.errors) unless updated
+
+        render json: prompt, serializer: PromptSerializer, status: :ok
+      end
+
+      def create
+        prompt = current_user.prompts.new(prompt_params)
+        return render_bad_request(prompt.errors) unless prompt.save
+
+        render json: prompt, serializer: PromptSerializer, status: :created
+      end
+
+      private
+
+      def prompt_id
+        params.require(:id)
+      end
+
+      def prompt_params
+        params.permit(:body)
+      end
+    end
+  end
+end

--- a/app/models/prompt.rb
+++ b/app/models/prompt.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'aasm'
+
+# A public writing prompt
+class Prompt < ApplicationRecord
+  include AASM
+
+  belongs_to :submitter, class_name: 'User'
+  validates :body, presence: true, uniqueness: { case_sensitive: false }
+
+  aasm do
+    state :approved, initial: true
+    state :removed
+
+    event :approve do
+      transitions from: :removed, to: :approved
+    end
+
+    event :remove do
+      transitions from: :approved, to: :removed
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
   has_secure_password
 
   has_many :entries, dependent: :destroy
+  has_many :prompts, foreign_key: 'submitter_id', dependent: :nullify
 
   validates :username, presence: true, uniqueness: true
   validates :email, presence: true, uniqueness: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,4 +8,6 @@ class User < ApplicationRecord
 
   validates :username, presence: true, uniqueness: true
   validates :email, presence: true, uniqueness: true
+
+  enum user_type: { user: 'user', admin: 'admin' }
 end

--- a/app/serializers/prompt_serializer.rb
+++ b/app/serializers/prompt_serializer.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class PromptSerializer < ActiveModel::Serializer
+  attributes :id, :body
+  has_one :submitter, serializer: UserSerializer
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,12 @@ Rails.application.routes.draw do
 
       resources :users, only: [:create]
       resources :entries, except: [:new]
-      resources :prompts, except: %i[new destroy]
+      resources :prompts, except: %i[new destroy] do
+        member do
+          put 'approve'
+          put 'remove'
+        end
+      end
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
 
       resources :users, only: [:create]
       resources :entries, except: [:new]
+      resources :prompts, except: %i[new destroy]
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,9 +5,9 @@ Rails.application.routes.draw do
     namespace :v1 do
       post 'login', to: 'authentication#login'
 
-      resources :users, only: [:create]
-      resources :entries, except: [:new]
-      resources :prompts, except: %i[new destroy] do
+      resources :users, only: :create
+      resources :entries, except: :new
+      resources :prompts, except: :new do
         member do
           put 'approve'
           put 'remove'

--- a/db/migrate/20191021160733_add_user_type_to_users.rb
+++ b/db/migrate/20191021160733_add_user_type_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddUserTypeToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column(:users, :user_type, :string, null: false, default: 'user')
+  end
+end

--- a/db/migrate/20191021171250_create_prompts.rb
+++ b/db/migrate/20191021171250_create_prompts.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreatePrompts < ActiveRecord::Migration[6.0]
+  def change
+    create_table :prompts do |t|
+      t.references :submitter, index: true, foreign_key: { to_table: :users }
+      t.text :body, null: false
+      t.string :aasm_state
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_20_192258) do
+ActiveRecord::Schema.define(version: 2019_10_21_160733) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,6 +31,7 @@ ActiveRecord::Schema.define(version: 2019_09_20_192258) do
     t.string "password_digest"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "user_type", default: "user", null: false
   end
 
   add_foreign_key "entries", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_21_160733) do
+ActiveRecord::Schema.define(version: 2019_10_21_171250) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,15 @@ ActiveRecord::Schema.define(version: 2019_10_21_160733) do
     t.index ["user_id"], name: "index_entries_on_user_id"
   end
 
+  create_table "prompts", force: :cascade do |t|
+    t.bigint "submitter_id"
+    t.text "body", null: false
+    t.string "aasm_state"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["submitter_id"], name: "index_prompts_on_submitter_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "username", null: false
     t.string "email", null: false
@@ -35,4 +44,5 @@ ActiveRecord::Schema.define(version: 2019_10_21_160733) do
   end
 
   add_foreign_key "entries", "users"
+  add_foreign_key "prompts", "users", column: "submitter_id"
 end

--- a/test/controllers/api/v1/prompts_controller_test.rb
+++ b/test/controllers/api/v1/prompts_controller_test.rb
@@ -57,6 +57,28 @@ module API
         post api_v1_prompts_url, headers: @headers, params: params
         assert_response :bad_request
       end
+
+      test 'admin can approve' do
+        headers = { 'Authorization' => generate_token(users(:admin)) }
+        put "#{api_v1_prompts_url}/#{@removed.id}/approve", headers: headers
+        assert_response :no_content
+      end
+
+      test 'admin can remove' do
+        headers = { 'Authorization' => generate_token(users(:admin)) }
+        put "#{api_v1_prompts_url}/#{@approved.id}/remove", headers: headers
+        assert_response :no_content
+      end
+
+      test 'user cannot approve' do
+        put "#{api_v1_prompts_url}/#{@removed.id}/approve", headers: @headers
+        assert_response :unauthorized
+      end
+
+      test 'user cannot remove' do
+        put "#{api_v1_prompts_url}/#{@approved.id}/remove", headers: @headers
+        assert_response :unauthorized
+      end
     end
   end
 end

--- a/test/controllers/api/v1/prompts_controller_test.rb
+++ b/test/controllers/api/v1/prompts_controller_test.rb
@@ -10,6 +10,7 @@ module API
         @headers = { 'Authorization' => token }
         @approved = prompts(:wordbank_fiction)
         @removed = prompts(:spam)
+        @approved2 = prompts(:user_two)
       end
 
       test 'requires authentication' do
@@ -37,8 +38,7 @@ module API
       end
 
       test "can GET #show for another user's prompt" do
-        prompt = prompts(:user_two)
-        get "#{api_v1_prompts_url}/#{prompt.id}", headers: @headers
+        get "#{api_v1_prompts_url}/#{@approved2.id}", headers: @headers
         assert_response :success
       end
 
@@ -50,6 +50,16 @@ module API
       test 'can POST #create' do
         post api_v1_prompts_url, headers: @headers, params: { body: 'testing' }
         assert_response :created
+      end
+
+      test 'can DELETE #destroy' do
+        delete "#{api_v1_prompts_url}/#{@approved.id}", headers: @headers
+        assert_response :success
+      end
+
+      test "cannot DELETE another user's prompt" do
+        delete "#{api_v1_prompts_url}/#{@approved2.id}", headers: @headers
+        assert_response :not_found
       end
 
       test 'returns model errors upon bad #create' do

--- a/test/fixtures/prompts.yml
+++ b/test/fixtures/prompts.yml
@@ -2,3 +2,14 @@ wordbank_fiction:
   submitter: one
   body: Take the words salt, invisible, night, music, and structure. Write
     a scene that includes all of the words.
+  aasm_state: approved
+
+user_two:
+  submitter: two
+  body: My name is User Two. This is my first prompt.
+  aasm_state: approved
+
+spam:
+  submitter: two
+  body: spamspamspamspamspamspamspam
+  aasm_state: removed

--- a/test/fixtures/prompts.yml
+++ b/test/fixtures/prompts.yml
@@ -1,0 +1,4 @@
+wordbank_fiction:
+  submitter: one
+  body: Take the words salt, invisible, night, music, and structure. Write
+    a scene that includes all of the words.

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -7,3 +7,9 @@ two:
   username: User2
   email: user2@foo.bar
   password_digest: foobar
+
+admin:
+  username: Admin
+  email: admin@foo.bar
+  password_digest: foobar
+  user_type: admin

--- a/test/models/prompt_test.rb
+++ b/test/models/prompt_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class PromptTest < ActiveSupport::TestCase
+  setup do
+    @user = users(:one)
+    @prompt = prompts(:wordbank_fiction)
+  end
+
+  test 'has attributes' do
+    assert_equal @user, @prompt.submitter
+    assert_match(/Write a scene/, @prompt.body)
+  end
+
+  test 'validates uniqueness of body' do
+    duplicate = Prompt.new(submitter: @user, body: @prompt.body.upcase)
+    assert_not duplicate.valid?
+  end
+
+  test 'has initial state' do
+    prompt = Prompt.create(submitter: @user, body: 'foobar')
+    assert prompt.approved?
+  end
+
+  test 'can remove a prompt' do
+    @prompt.remove
+    assert_not @prompt.approved?
+    assert @prompt.removed?
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -33,4 +33,11 @@ class UserTest < ActiveSupport::TestCase
 
     assert_match(/is not a valid user_type/, exception.message)
   end
+
+  test 'preserves prompt if submitter deleted' do
+    prompt = @user.prompts.first
+    @user.destroy!
+
+    assert_nil prompt.reload.submitter
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -5,6 +5,7 @@ require 'test_helper'
 class UserTest < ActiveSupport::TestCase
   setup do
     @user = users(:one)
+    @admin = users(:admin)
   end
 
   test 'has attributes' do
@@ -18,5 +19,18 @@ class UserTest < ActiveSupport::TestCase
     user.reload
 
     assert_not_nil user.password_digest
+  end
+
+  test 'has user types' do
+    assert @user.user?
+    assert_not @user.admin?
+    assert @admin.admin?
+  end
+
+  test 'enforces user type with rails validations' do
+    opts = { username: 'foo', email: 'bar', password: '1', user_type: 'foo' }
+    exception = assert_raises(ArgumentError) { User.new(opts) }
+
+    assert_match(/is not a valid user_type/, exception.message)
   end
 end

--- a/test/serializers/prompt_serializer_test.rb
+++ b/test/serializers/prompt_serializer_test.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'jwt_manager'
+
+class PromptSerializerTest < ActiveSupport::TestCase
+  setup do
+    @prompt = prompts(:wordbank_fiction)
+  end
+
+  test 'serializes prompt' do
+    actual = PromptSerializer.new(@prompt).as_json
+
+    assert_equal @prompt.id, actual[:id]
+    assert_equal @prompt.body, actual[:body]
+    assert_equal @prompt.submitter.username, actual[:submitter][:username]
+  end
+end


### PR DESCRIPTION
Since we want to encourage users to write daily, `Prompt`s offer them something to write about if their minds are drawing a blank. Prompts are user-submitted and are `approved` by default but can be `removed` by admins.